### PR TITLE
ci: Fix doc-dev workflow

### DIFF
--- a/.github/workflows/docs-dev.yml
+++ b/.github/workflows/docs-dev.yml
@@ -3,7 +3,7 @@ name: docs-dev
 on:
   # trigger deployment on every push to main branch
   push:
-    branches-ignores: [master]
+    branches-ignore: [master]
   # trigger deployment manually
   workflow_dispatch:
 


### PR DESCRIPTION
The on/push/branches-ignore statement has a typo, executing both docs-dev and doc-prod on master branch.