### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs-dev.yml
+++ b/.github/workflows/docs-dev.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   docs-dev:
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docs-dev.yml
+++ b/.github/workflows/docs-dev.yml
@@ -6,6 +6,9 @@ on: workflow_dispatch
     #branches-ignore: [master]
   # trigger deployment manually
 
+permissions:
+  contents: write
+
 jobs:
   docs-dev:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-dev.yml
+++ b/.github/workflows/docs-dev.yml
@@ -6,9 +6,6 @@ on: workflow_dispatch
     #branches-ignore: [master]
   # trigger deployment manually
 
-permissions:
-  contents: write
-
 jobs:
   docs-dev:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/PinguinoIDE/pinguinoide.github.io/security/code-scanning/2](https://github.com/PinguinoIDE/pinguinoide.github.io/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/docs-dev.yml` so the workflow does not inherit potentially overbroad defaults.  
Best fix without changing functionality: define workflow-level permissions with least privilege needed for current steps:

- `contents: read` (needed for checkout/build context access)
- `pages: write` and `id-token: write` are commonly needed for official Pages deploy action, but this workflow uses `crazy-max/ghaction-github-pages` pushing to `gh-pages` branch, so the key needed is:
- `contents: write` (to push commits to `gh-pages`)

Given current behavior (branch push deployment), set:
- `contents: write`

This preserves deploy functionality while making permissions explicit and constrained to a single scope instead of implicit defaults.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
